### PR TITLE
Replace manifoldjs-lib with pwabuilder-lib

### DIFF
--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -2,7 +2,7 @@
 
 var url = require('url'),
     Q = require('q');
-var lib = require('manifoldjs-lib');
+var lib = require('pwabuilder-lib');
 var utils = lib.utils;
 
 

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -18,7 +18,7 @@ var path = require('path'),
     
 var Q = require('q');
 
-var manifoldjsLib = require('manifoldjs-lib');
+var manifoldjsLib = require('pwabuilder-lib');
 
 var PlatformBase = manifoldjsLib.PlatformBase,
     manifestTools = manifoldjsLib.manifestTools,

--- a/lib/validationRules/_placeholder.js
+++ b/lib/validationRules/_placeholder.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// var manifoldjsLib = require('manifoldjs-lib');
+// var manifoldjsLib = require('pwabuilder-lib');
 
 // var validationConstants = manifoldjsLib.constants.validation,
 //     imageValidation =  manifoldjsLib.manifestTools.imageValidation,

--- a/lib/validationRules/requiredIcon.js
+++ b/lib/validationRules/requiredIcon.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var manifoldjsLib = require('manifoldjs-lib');
+var manifoldjsLib = require('pwabuilder-lib');
 
 var validationConstants = manifoldjsLib.constants.validation,
     imageValidation =  manifoldjsLib.manifestTools.imageValidation;

--- a/lib/validationRules/requiredSmallIcon.js
+++ b/lib/validationRules/requiredSmallIcon.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var manifoldjsLib = require('manifoldjs-lib');
+var manifoldjsLib = require('pwabuilder-lib');
 
 var validationConstants = manifoldjsLib.constants.validation,
     imageValidation =  manifoldjsLib.manifestTools.imageValidation;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "dependencies": {
     "q": "^1.4.1",
-    "manifoldjs-lib": "^0.1.1"
+    "pwabuilder-lib": "^2.0.0"
   },
   "devDependencies": {
     "blanket": "1.1.6",

--- a/test/manifestTools/manifestTools.js
+++ b/test/manifestTools/manifestTools.js
@@ -2,7 +2,7 @@
 
 var should = require('should');
 
-var lib = require('manifoldjs-lib');
+var lib = require('pwabuilder-lib');
 
 var manifest = require('../../lib/manifest.js');
 

--- a/test/manifestTools/transformations.js
+++ b/test/manifestTools/transformations.js
@@ -2,7 +2,7 @@
 
 var should = require('should');
 
-var lib = require('manifoldjs-lib');
+var lib = require('pwabuilder-lib');
 
 var manifest = require('../../lib/manifest.js');
 

--- a/test/manifestTools/validations/requiredExtensionIcon.js
+++ b/test/manifestTools/validations/requiredExtensionIcon.js
@@ -2,7 +2,7 @@
 
 var should = require('should');
 
-var lib = require('manifoldjs-lib');
+var lib = require('pwabuilder-lib');
 var validationConstants = lib.constants.validation;
 
 var constants = require('../../../lib/constants'),  

--- a/test/manifestTools/validations/requiredFavicon.js
+++ b/test/manifestTools/validations/requiredFavicon.js
@@ -2,7 +2,7 @@
 
 var should = require('should');
 
-var lib = require('manifoldjs-lib');
+var lib = require('pwabuilder-lib');
 var validationConstants = lib.constants.validation;
 
 var constants = require('../../../lib/constants'),

--- a/test/manifestTools/validations/requiredIcon.js
+++ b/test/manifestTools/validations/requiredIcon.js
@@ -2,7 +2,7 @@
 
 var should = require('should');
 
-var lib = require('manifoldjs-lib');
+var lib = require('pwabuilder-lib');
 var validationConstants = lib.constants.validation;
 
 var constants = require('../../../lib/constants'),


### PR DESCRIPTION
I'm submitting this PR because I created my own test platform with manifoldjs-strawman, but when I tried to add it to pwabuilder CLI Tool, it wasn't recognized. After looking into my project, I noticed that the core libraries were outdated. So, i replaced the old manifoldjs-lib with pwabuilder-lib and it works like a charm. 

<img width="816" alt="mytest" src="https://user-images.githubusercontent.com/3893598/43919589-c41233d8-9bec-11e8-8cb3-6877bf594cd2.png">




